### PR TITLE
Hotfix for cursed visual bug

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -2,7 +2,11 @@ html,
 body {
   max-width: 100vw;
   overflow-x: hidden;
+  /*
+  Need a better alternative to scrollbar-gutter for preventing
+  page offset when scrollbar is visible.
   scrollbar-gutter: stable;
+  */
 }
 
 body {

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -17,7 +17,6 @@ body {
       rgb(var(--background-end-rgb))
     )
     rgb(var(--background-start-rgb));
-    scrollbar-gutter: stable;
 }
 
 a {


### PR DESCRIPTION
![bug](https://user-images.githubusercontent.com/33499052/217480075-9e29d6ec-370d-4628-b5c3-2cf60aef338c.png)
The entire website is offset to the left. Not anymore.